### PR TITLE
Add Docker build for Jetson AGX Orin with PyTorch 2.8 and ROS 2 Jazzy

### DIFF
--- a/docker/Dockerfile.agxorin
+++ b/docker/Dockerfile.agxorin
@@ -1,0 +1,160 @@
+# -------- Stage 1: Build
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} as builder
+
+ENV CUDA_HOME=/usr/local/cuda \
+    DEBIAN_FRONTEND=noninteractive \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8 \
+    PIP_INDEX_URL=https://pypi.org/simple \
+    PATH=/usr/local/cuda/bin:$PATH \
+    LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
+
+# -- Base setup
+RUN apt update && apt install -y \
+    sudo sed procps locales \
+    software-properties-common zip cmake g++ gnupg2 lsb-release && \
+    add-apt-repository universe && \
+    locale-gen en_US en_US.UTF-8 && \
+    update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+
+# -- Lightweight Python deps
+RUN python3 -m pip install -U pip jetson-stats && \
+    pip install tqdm plotly kaleido pandas nbformat ipykernel timm \
+    onnxruntime==1.21.0 cuda-python onnx_graphsurgeon==0.5.6 onnx==1.17.0 gdown
+
+# -- Build Triton
+WORKDIR /opt
+RUN git clone https://github.com/triton-lang/triton.git && \
+    cd triton && \
+    pip install -r python/requirements.txt && \
+    MAX_JOBS=8 python3 -m pip wheel . --no-build-isolation -v -w dist && \
+    pip install dist/triton*.whl && \
+    cd .. && rm -rf triton
+
+# -- Fix base image
+RUN echo "/usr/local/cuda/lib64" > /etc/ld.so.conf.d/nvidia.conf && \
+    echo "/usr/lib/aarch64-linux-gnu/nvidia" >> /etc/ld.so.conf.d/nvidia.conf && \
+    rm -f /etc/ld.so.conf.d/nvidia-tegra.conf && \
+    ldconfig
+
+# -- Build torch2trt
+ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/lib/aarch64-linux-gnu/nvidia:${LD_LIBRARY_PATH}" \
+    PATH=/usr/local/cuda/bin:/usr/local/mpi/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/ucx/bin:/opt/amazon/efa/bin:/opt/tensorrt/bin:/usr/local/lib/python3.12/dist-packages/torch_tensorrt/bin
+
+WORKDIR /opt/torch2trt
+RUN git clone https://github.com/NVIDIA-AI-IOT/torch2trt /opt/torch2trt && \
+    sed -i '/^[[:space:]]*return[[:space:]]\+isinstance(x, torch.Tensor)/c\    return isinstance(x, torch.Tensor) and (x.dtype is torch.half or x.dtype is torch.float or x.dtype == torch.bool)' /opt/torch2trt/torch2trt/flattener.py && \
+    sed -i 's|^set(CUDA_ARCHITECTURES.*|#|g' /opt/torch2trt/CMakeLists.txt && \
+    sed -i 's|Catch2_FOUND|False|g' /opt/torch2trt/CMakeLists.txt && \
+    cmake -B build -DCUDA_ARCHITECTURES=87 . && \
+    cmake --build build --target install && \
+    ldconfig && \
+    rm -rf /opt/torch2trt
+
+COPY ./torch2trt-0.5.0-py3-none-any.whl /tmp/
+
+# -------- Stage 2: Runtime (Final Image) --------
+FROM ${BASE_IMAGE} as final
+
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8 \
+    CUDA_VISIBLE_DEVICES=0 \
+    CUDA_MPS_PIPE_DIRECTORY=/tmp/nvidia-mps \
+    CUDA_MPS_LOG_DIRECTORY=/tmp/nvidia-mps/log \
+    ROS_DISTRO=jazzy \
+    ROS_VERSION=2 \
+    ROS_PYTHON_VERSION=3 \
+    LD_LIBRARY_PATH=/usr/local/cuda/lib64:/usr/lib/aarch64-linux-gnu/nvidia:/usr/local/lib:/usr/lib/aarch64-linux-gnu:/usr/local/cuda/compat/lib.real:/usr/local/lib/python3.12/dist-packages/torch/lib:/usr/local/lib/python3.12/dist-packages/torch_tensorrt/lib \
+    PATH=/usr/local/cuda/bin:/usr/local/mpi/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/ucx/bin:/opt/amazon/efa/bin:/opt/tensorrt/bin:/usr/local/lib/python3.12/dist-packages/torch_tensorrt/bin
+
+#  ROS2 Jazzy Install
+RUN apt update && apt install -y \
+    git sudo procps python3-pip locales \
+    software-properties-common gnupg2 lsb-release && \
+    add-apt-repository universe && \
+    sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen && \
+    curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg && \
+    echo "deb [arch=arm64 signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $VERSION_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list && \
+    apt update && \
+    apt install -y ros-jazzy-desktop ros-dev-tools python3-colcon-common-extensions && \
+    rm -rf /var/lib/apt/lists/*
+    #echo "source /opt/ros/jazzy/setup.bash" >> /etc/bash.bashrc && \
+    
+# -- Copy runtime files
+COPY --from=builder /usr/local/lib /usr/local/lib/
+COPY --from=builder /usr/local/bin /usr/local/bin/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libcuda* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /usr/local/jetson_stats /usr/local/jetson_stats/
+COPY --from=builder /usr/local/lib/libtorch2trt_plugins.so /usr/local/lib/
+#COPY --from=builder /usr/lib/aarch64-linux-gnu/nvidia /usr/lib/aarch64-linux-gnu/nvidia/
+COPY --from=builder /usr/local/share /usr/local/share/
+COPY --from=builder /usr/local/etc/jupyter /usr/local/etc/jupyter/
+COPY --from=builder /etc/ld.so.conf.d /etc/ld.so.conf.d/
+COPY --from=builder /tmp/torch2trt-0.5.0-py3-none-any.whl /tmp/
+
+# -- MPS dirs and install torch2trt wheel.
+RUN ldconfig && \
+    mkdir -p ${CUDA_MPS_PIPE_DIRECTORY} ${CUDA_MPS_LOG_DIRECTORY} && \
+    python3 -m pip install --no-deps /tmp/torch2trt-0.5.0-py3-none-any.whl && \
+    python3 -m pip install cuda-core[cu12] && \
+    mkdir -p /usr/local/lib/python3.12/models && \
+    rm -f /tmp/torch2trt*.whl
+
+# -- Install visual-perception-engine
+WORKDIR /opt
+RUN git clone https://github.com/nasa-jpl/visual-perception-engine.git && \
+    python3 -m pip install ./visual-perception-engine --no-deps
+    #mkdir -p visual-perception-engine/models/checkpoints
+    #gdown should perhaps be pip installed locally. If following 2 lines are run in image it adds 694mb to image.
+    #gdown --folder https://drive.google.com/drive/folders/1SWMlEqOE_7EWPCkMloDTXG1_mZAmeW3- \
+    #      -O visual-perception-engine/models/
+    #sudo python3 -c import vp_engine; vp_engine.export_default_models()
+
+# -- reduce size of image
+RUN rm -rf /root/.cache/pip && \
+    rm -rf /tmp/* && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set defaults (override with --build-arg as needed)
+ARG _UID=1000
+ARG _GID=1000
+ARG USER
+
+# Ensure MPS env (match these to what you actually use earlier)
+ENV CUDA_MPS_PIPE_DIRECTORY=/tmp/nvidia-mps \
+    CUDA_MPS_LOG_DIRECTORY=/tmp/nvidia-mps/log
+
+# Rename ubuntu user if needed, sync UID/GID, (re)create MPS dirs, and fix ownership
+RUN install -d -m 1777 /tmp && \
+ install -d ${CUDA_MPS_PIPE_DIRECTORY} ${CUDA_MPS_LOG_DIRECTORY} && \
+ if id "ubuntu" >/dev/null 2>&1 && [ "$(id -u ubuntu)" = "${_UID}" ]; then \
+        usermod -l "${USER}" ubuntu && \
+        groupmod -n "${USER}" ubuntu && \
+        usermod -d "/home/${USER}" -m "${USER}"; \
+    fi && \
+    groupmod -g "${_GID}" "${USER}" && \
+    usermod -u "${_UID}" -g "${_GID}" -a -G video "${USER}" && \
+    echo "${USER} ALL=(ALL) NOPASSWD: ALL" > "/etc/sudoers.d/${USER}" && \
+    chmod 0440 "/etc/sudoers.d/${USER}" && \
+    mkdir -p "/home/${USER}/ros2_ws/src" && \
+    chown -R "${USER}:${USER}" "/home/${USER}" && \
+    chown "${USER}" "${CUDA_MPS_PIPE_DIRECTORY}" "${CUDA_MPS_LOG_DIRECTORY}" && \
+    rm -rf "/home/${USER}/home"
+
+USER ${USER}
+WORKDIR /home/${USER}
+
+# Optional: Build ROS workspace
+#RUN . /opt/ros/jazzy/setup.sh && \
+#    colcon build --symlink-install && \
+#    echo "source /home/${USER}/ros2_ws/install/setup.bash" >> /home/${USER}/.bashrc
+
+# -- Final setup
+COPY --chmod=755 entrypoint.sh /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["/bin/bash"]

--- a/docker/build_agxorin.sh
+++ b/docker/build_agxorin.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+export _UID="$(id -u)"
+export _GID="$(id -g)"
+export USER="${USER:-$(whoami)}"
+export DISPLAY=0
+export WORKSPACE="/opt/visual-perception-engine"
+export REPOS="/opt/visual-perception-engine"
+export DISPLAY="${DISPLAY:-:0}"
+
+if [ -z "${SSH_AUTH_SOCK:-}" ]; then
+  eval "$(ssh-agent -s)" >/dev/null
+fi
+
+#we'll build torch2trt wheel if needed. This works as it fails in Dockerfile.
+if [ ! -f ./torch2trt-0.5.0-py3-none-any.whl ]; then
+  source ./torch2trt_function.sh
+  build_torch2trt
+fi
+
+#Build image
+docker compose -f docker-compose-agxorin.yml build
+# --no-cache
+
+#Create container from image.
+# docker compose -f docker-compose-agxorin.yml up -d
+
+#container_name=$(docker compose ps -q | head -n1)

--- a/docker/docker-compose-agxorin.yml
+++ b/docker/docker-compose-agxorin.yml
@@ -1,0 +1,57 @@
+services:
+  visual-perception-engine:
+    build:
+      context: .
+      dockerfile: Dockerfile.agxorin
+      ssh:
+        - 'default'
+      args:
+        _UID: '${_UID}'
+        _GID: '${_GID}'
+        USER: '${USER}'
+        WORKSPACE: '${WORKSPACE}'
+        REPOS: '${REPOS}'
+        BASE_IMAGE: 'nvcr.io/nvidia/pytorch:25.06-py3-igpu'
+    ulimits:
+      rtprio:
+        soft: 90
+        hard: 95
+      nice:
+        soft: -20
+        hard: -20
+    cap_add:
+      - SYS_NICE
+    container_name: engine
+    image: visual-perception-engine:latest
+    runtime: nvidia
+    privileged: true
+    network_mode: host
+    ipc: host
+    stdin_open: true
+    tty: true
+    environment:
+      - DISPLAY=$DISPLAY
+      - QT_X11_NO_MITSHM=1
+      - USER=$USER
+    volumes:
+      - /home/${USER}/${WORKSPACE}:/home/${USER}/${WORKSPACE}
+      - /home/${USER}/rosbags:/home/${USER}/rosbags
+      - /data/ros:/data/ros
+      - /tmp/.X11-unix:/tmp/.X11-unix
+      - ${XAUTHORITY:-$HOME/.Xauthority}:/root/.Xauthority:rw
+      - ${XAUTHORITY:-$HOME/.Xauthority}:/home/${USER}/.Xauthority:rw
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
+      - /dev/input:/dev/input
+      - /dev/bus/usb:/dev/bus/usb
+      - ~/.ssh:/home/${USER}/.ssh:ro
+      - ~/.bashrc:/home/${USER}/.bashrc
+      - ~/.julia:/home/${USER}/.julia
+      - /run/jtop.sock:/run/jtop.sock # to be able to run jtop inside docker
+      - /opt/nvidia/nsight-systems/2024.5.4:/nsys # to be able to run nsys inside docker
+      - /tmp/nvidia-mps:/tmp/nvidia-mps
+      - /tmp/nvidia-log:/tmp/nvidia-log
+    command: bash
+    devices:
+      - "/dev:/dev"
+      - "/run/dbus:/run/dbus"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+export workspace="/opt/visual-perception-engine"
+export CUDA_MPS_PIPE_DIRECTORY="${CUDA_MPS_PIPE_DIRECTORY:-/tmp/nvidia-mps}"
+export CUDA_MPS_LOG_DIRECTORY="${CUDA_MPS_LOG_DIRECTORY:-/tmp/nvidia-mps/log}"
+mkdir -p "$CUDA_MPS_PIPE_DIRECTORY" "$CUDA_MPS_LOG_DIRECTORY"
+sudo chown $USER $CUDA_MPS_PIPE_DIRECTORY $CUDA_MPS_LOG_DIRECTORY
+
+# Start MPS control daemon if not already running
+if ! pgrep -x "nvidia-cuda-mps-control" > /dev/null; then
+    echo "Starting CUDA MPS daemon..."
+    nvidia-cuda-mps-control -d
+fi
+
+# If no command is passed, keep container alive
+if [ $# -eq 0 ]; then
+    echo "No command provided. Starting bash to keep the container running."
+    exec /bin/bash
+else
+    exec "$@"
+fi

--- a/docker/torch2trt_function.sh
+++ b/docker/torch2trt_function.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+
+build_torch2trt() {
+    echo "[INFO] Cloning and patching torch2trt..."
+
+    git clone https://github.com/NVIDIA-AI-IOT/torch2trt /tmp/torch2trt
+    pushd /tmp/torch2trt
+
+    # Patch flattener.py
+    sed -i '/^[[:space:]]*return[[:space:]]\+isinstance(x, torch.Tensor)/c\    return isinstance(x, torch.Tensor) and (x.dtype is torch.half or x.dtype is torch.float or x.dtype == torch.bool)' ./torch2trt/flattener.py
+
+    # Patch CMakeLists.txt
+    sed -i 's|^set(CUDA_ARCHITECTURES.*|#|g' ./CMakeLists.txt
+    sed -i 's|Catch2_FOUND|False|g' ./CMakeLists.txt
+
+    # Patch setup.py for CUDA_HOME
+    python3 - <<EOF
+import os, textwrap
+p = "/tmp/torch2trt/setup.py"
+block = textwrap.dedent("""\
+    import os
+    import setuptools
+    CUDA_HOME = os.environ.get("CUDA_HOME") or "/usr/local/cuda"
+    os.environ["CUDA_HOME"] = CUDA_HOME
+    os.environ.setdefault("CUDA_PATH", CUDA_HOME)
+    import torch.utils.cpp_extension as _cpp
+    _cpp.CUDA_HOME = os.environ["CUDA_HOME"]
+""")
+with open(p, "r+", encoding="utf-8") as f:
+    src = f.read()
+    if block not in src:
+        f.seek(0)
+        f.write(block + "\\n" + src)
+        f.truncate()
+EOF
+
+    # Build the wheel
+    python3 -m pip wheel --no-cache-dir --no-deps -w . .
+
+    popd
+    mv /tmp/torch2trt/torch2trt-0.5.0-py3-none-any.whl .
+    rm -rf /tmp/torch2trt
+    echo "[INFO] torch2trt wheel built successfully."
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,12 +38,12 @@ dependencies = [
   "onnxruntime==1.21.0",
   "onnx_graphsurgeon==0.5.6",
   "onnx==1.17.0",
-  "torch2trt==0.5.0",
   "torch>=2.4.0",
-  "tensorrt==10.4.0",
+  "tensorrt==10.7.0",
   "torchvision>0.19.0",
   "cuda-python>=12.6",
-  "numpy>=1.26.4",
+  "cuda-core>=0.3.1",
+  "numpy==1.26.4",
   "setuptools"
 ]
 


### PR DESCRIPTION
## Summary

This PR adds a Dockerfile and supporting files that builds a fully functional Docker compose image for the NASA-JPL `visual-perception-engine` targeting the NVIDIA Jetson AGX Orin Developer Kit.

## Details

- **Base Image:** `nvcr.io/nvidia/pytorch:25.06-py3-igpu` (Ubuntu 24.04.2)
- **JetPack Version:** 6.2.1 (R36.4.4)
- **CUDA Version:** 12.9
- **Python Version:** 3.12
- **ROS 2 Distribution:** Jazzy Desktop
- Includes all runtime dependencies needed to run `vp_engine`

## Motivation

This configuration ensures forward compatibility with the upcoming **Jetson Thor** platform, while providing a stable ROS 2, PyTorch, full torch_tensorrt, and torch2trt development environment aligned with NVIDIA’s JetPack 6.2.1.

## Notes

- `/opt/visual-perception-engine` is used as the working directory

<details>
<summary>Final image details</summary>

```text
Base Docker Image:
  nvcr.io/nvidia/pytorch:25.06-py3-igpu
OS and Platform:
  /etc/nv_tegra_release: R36.4.4 aarch64
  /etc/os-release: Ubuntu 24.04.2 LTS
  /usr/local/cuda-12.9

Installed Directories:
  /opt/amazon
  /opt/hpcx
  /opt/nvidia
  /opt/pytorch
  /opt/ros/jazzy
  /opt/tensorrt
  /opt/visual-perception-engine

Key Software Versions:
  Python: 3.12.3
  ROS 2: jazzy-desktop
  torch: 2.8.0a0+5228986c39.nv25.6
  torchvision: 0.22.0a0+95f10a4e
  torch_tensorrt: 2.8.0a0
  torch2trt: 0.5.0
  tensorrt: 10.11.0.33
  triton: 3.4.0+git198fd9b9
  onnx: 1.17.0
  onnxruntime: 1.21.0
  timm: 1.0.19
  jupyterlab: 4.4.3
  vp_engine: 0.1.0

CUDA Environment:
  CUDA_VERSION=12.9.11.009
  CUDA_VISIBLE_DEVICES=0
  CUDA_DRIVER_VERSION=12.9.40580548
  CUDNN_VERSION=9.10.2.21
  NCCL_VERSION=2.27.3
  TENSORRT_VERSION=10.11.0.33
  TORCH_CUDA_ARCH_LIST=8.7 10.1+PTX

Additional Components:
  POLYGRAPHY_VERSION=0.49.20
  ONNX_GRAPH_SURGEON=0.5.6
  PYTORCH_TRITON=3.3.0+git96316ce52.nvinternal
  MODEL_OPT_VERSION=0.29.0
  MOFED_VERSION=5.4-rdmacore50.0
  HPCX_VERSION=2.23
  OPENMPI_VERSION=4.1.7
  OPENUCX_VERSION=1.19.0
